### PR TITLE
Explanation for the OS X users

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Tested with the following Arduino IDE versions: 1.6.5-r2,
 - Make sure you use one of the supported versions of Arduino IDE and have ESP8266 core installed.
 - Download the tool archive from [releases page](https://github.com/esp8266/arduino-esp8266fs-plugin/releases/latest).
 - In your Arduino sketchbook directory, create tools directory if it doesn't exist yet.
-- Unpack the tool into tools directory (the path will look like `<home_dir>/Arduino/tools/ESP8266FS/tool/esp8266fs.jar)`.
+- Unpack the tool into tools directory (the path will look like `<home_dir>/Arduino/tools/ESP8266FS/tool/esp8266fs.jar)` *.
 - Restart Arduino IDE.
+
+* On the OS X create the tools directory in ~/Documents/Arduino/ and unpack the files there.
 
 ## Usage
 - Open a sketch (or create a new one and save it).

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Tested with the following Arduino IDE versions: 1.6.5-r2,
 - Make sure you use one of the supported versions of Arduino IDE and have ESP8266 core installed.
 - Download the tool archive from [releases page](https://github.com/esp8266/arduino-esp8266fs-plugin/releases/latest).
 - In your Arduino sketchbook directory, create tools directory if it doesn't exist yet.
-- Unpack the tool into tools directory (the path will look like `<home_dir>/Arduino/tools/ESP8266FS/tool/esp8266fs.jar)` *.
-- Restart Arduino IDE.
+- Unpack the tool into tools directory (the path will look like `<home_dir>/Arduino/tools/ESP8266FS/tool/esp8266fs.jar)`.
+- Restart Arduino IDE. 
 
-* On the OS X create the tools directory in ~/Documents/Arduino/ and unpack the files there.
+On the OS X create the tools directory in ~/Documents/Arduino/ and unpack the files there
 
 ## Usage
 - Open a sketch (or create a new one and save it).


### PR DESCRIPTION
Hey, 

I am new to the Arduino IDE and I have spent about 2 hours to find where the tools directory is on OS X. Thought it might be helpful for other mac users to see how to use the plugin on OS X.
