### PR TITLE
 copy of the SPIFFS image in project folder

### DIFF
--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -260,7 +260,7 @@ public class ESP8266FS implements Tool {
     String dataPath = dataFolder.getAbsolutePath();
     String toolPath = tool.getAbsolutePath();
     String sketchName = editor.getSketch().getName();
-    String imagePath = getBuildFolderPath(editor.getSketch()) + "/" + sketchName + ".spiffs.bin";
+    String imagePath = getBuildFolderPath(editor.getSketch()) + "\\" + sketchName + ".spiffs.bin";
     String resetMethod = BaseNoGui.getBoardPreferences().get("upload.resetmethod");
     String uploadSpeed = BaseNoGui.getBoardPreferences().get("upload.speed");
     String uploadAddress = BaseNoGui.getBoardPreferences().get("build.spiffs_start");

--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -302,7 +302,7 @@ public class ESP8266FS implements Tool {
     title = "SPIFFS Copy";
     message = "Would you like a copy of the SPIFFS image in your project folder?";
 
-    if(JOptionPane.showOptionDialog(editor, message, title, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[1]) == JOptionPane.YES_OPTION){
+    if(JOptionPane.showOptionDialog(editor, message, title, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0]) == JOptionPane.YES_OPTION){
       File source = new File(imagePath);
       File dest = new File(sketchFldr + "\\" + sketchName + ".spiffs.bin");
       try {

--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -302,7 +302,7 @@ public class ESP8266FS implements Tool {
     title = "SPIFFS Copy";
     message = "Would you like a copy of the SPIFFS image in your project folder?";
 
-    if(JOptionPane.showOptionDialog(null, message, title, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[1]) == JOptionPane.YES_OPTION){
+    if(JOptionPane.showOptionDialog(editor, message, title, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[1]) == JOptionPane.YES_OPTION){
       File source = new File(imagePath);
       File dest = new File(sketchFldr + "\\" + sketchName + ".spiffs.bin");
       try {

--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -28,6 +28,9 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.lang.reflect.Field;
@@ -260,6 +263,7 @@ public class ESP8266FS implements Tool {
     String dataPath = dataFolder.getAbsolutePath();
     String toolPath = tool.getAbsolutePath();
     String sketchName = editor.getSketch().getName();
+    String sketchFldr = editor.getSketch().getFolder();
     String imagePath = getBuildFolderPath(editor.getSketch()) + "\\" + sketchName + ".spiffs.bin";
     String resetMethod = BaseNoGui.getBoardPreferences().get("upload.resetmethod");
     String uploadSpeed = BaseNoGui.getBoardPreferences().get("upload.speed");
@@ -293,6 +297,21 @@ public class ESP8266FS implements Tool {
       editor.statusError(e);
       editor.statusError("SPIFFS Create Failed!");
       return;
+    }
+    
+    title = "SPIFFS Copy";
+    message = "Would you like a copy of the SPIFFS image in your project folder?";
+
+    if(JOptionPane.showOptionDialog(null, message, title, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[1]) == JOptionPane.YES_OPTION){
+      File source = new File(imagePath);
+      File dest = new File(sketchFldr + "\\" + sketchName + ".spiffs.bin");
+      try {
+         Files.copy(source.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
+         System.out.println("Copied SPIFFS image");
+      } catch (IOException e) {
+        System.out.println(e);
+        editor.statusError("Copy SPIFFS image failed");
+      }
     }
 
     editor.statusNotice("SPIFFS Uploading Image...");

--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -263,7 +263,7 @@ public class ESP8266FS implements Tool {
     String dataPath = dataFolder.getAbsolutePath();
     String toolPath = tool.getAbsolutePath();
     String sketchName = editor.getSketch().getName();
-    String sketchFldr = editor.getSketch().getFolder();
+    String sketchFldr = getBuildFolderPath(editor.getSketch().getFolder());
     String imagePath = getBuildFolderPath(editor.getSketch()) + "\\" + sketchName + ".spiffs.bin";
     String resetMethod = BaseNoGui.getBoardPreferences().get("upload.resetmethod");
     String uploadSpeed = BaseNoGui.getBoardPreferences().get("upload.speed");

--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -263,7 +263,6 @@ public class ESP8266FS implements Tool {
     String dataPath = dataFolder.getAbsolutePath();
     String toolPath = tool.getAbsolutePath();
     String sketchName = editor.getSketch().getName();
-    String sketchFldr = getBuildFolderPath(editor.getSketch().getFolder());
     String imagePath = getBuildFolderPath(editor.getSketch()) + "\\" + sketchName + ".spiffs.bin";
     String resetMethod = BaseNoGui.getBoardPreferences().get("upload.resetmethod");
     String uploadSpeed = BaseNoGui.getBoardPreferences().get("upload.speed");
@@ -304,7 +303,7 @@ public class ESP8266FS implements Tool {
 
     if(JOptionPane.showOptionDialog(editor, message, title, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0]) == JOptionPane.YES_OPTION){
       File source = new File(imagePath);
-      File dest = new File(sketchFldr + "\\" + sketchName + ".spiffs.bin");
+      File dest = new File(editor.getSketch().getFolder(),"\\" + sketchName + ".spiffs.bin");
       try {
          Files.copy(source.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
          System.out.println("Copied SPIFFS image");


### PR DESCRIPTION
I added a dialog box asking the users if they want a copy of the SPIFFS image in their project folder. This makes it easier for users uploading their .bin files to online services.

In our case IOTAppStory.com which I developed together with Andreas Spiess (SensorsIot). We recently added SPIFFS support.

I was not able to compile the whole plugin in Eclipse due to missing librairies. I was however able to compile and test my changes in a test file. And after a small change past Travis CI

Any feedback would be welcome.

UPDATE! This is my second pull request. And it seams like I made a real mess with the commits. Just skip to the "Files changed" for the final version...