### PR TITLE
Use same password dialog as in Arduino IDE to authenticate for FS data upload

### DIFF
--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -34,12 +34,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.JOptionPane;
 
+
 import processing.app.PreferencesData;
 import processing.app.Editor;
 import processing.app.Base;
 import processing.app.BaseNoGui;
 import processing.app.Platform;
 import processing.app.Sketch;
+import processing.app.forms.PasswordAuthorizationDialog;
 import processing.app.tools.Tool;
 import processing.app.helpers.ProcessUtils;
 import processing.app.debug.TargetPlatform;
@@ -307,7 +309,23 @@ public class ESP8266FS implements Tool {
       
       System.out.println("[SPIFFS] IP     : "+serialPort);
       System.out.println();
-      sysExec(new String[]{pythonCmd, espota.getAbsolutePath(), "-i", serialPort, "-s", "-f", imagePath});
+
+      PasswordAuthorizationDialog dialog = new PasswordAuthorizationDialog(
+             editor, "Type board password to upload new data");
+      dialog.setLocationRelativeTo(editor);
+      dialog.setVisible(true);
+      if (dialog.isCancelled()) {
+        editor.statusNotice("Upload cancelled");
+        return;
+      }
+      String pass = dialog.getPassword();
+      if (pass.isEmpty()) {
+        sysExec(new String[]{pythonCmd, espota.getAbsolutePath(),
+            "-i", serialPort, "-s", "-f", imagePath});
+      } else {
+        sysExec(new String[]{pythonCmd, espota.getAbsolutePath(),
+                             "-i", serialPort, "-a", pass, "-s", "-f", imagePath});
+      }
     } else {
       System.out.println("[SPIFFS] address: "+uploadAddress);
       System.out.println("[SPIFFS] reset  : "+resetMethod);


### PR DESCRIPTION
Entering blank password will work for non-authenticated case.
(it is a minor inconvenience to press enter for no-auth case, but major improvement if you want to work with secured ArduinoOTA boards)