### PR TITLE
Add upload.py and internal python in tools

### DIFF
--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -208,6 +208,12 @@ public class ESP8266FS implements Tool {
     File espota = new File(platform.getFolder()+"/tools");
     File esptool = new File(platform.getFolder()+"/tools");
     String serialPort = PreferencesData.get("serial.port");
+    String pythonCmd;
+    if(PreferencesData.get("runtime.os").contentEquals("windows"))
+      pythonCmd = "python.exe";
+    else
+      pythonCmd = "python";
+    String uploadCmd = "";
     
     //make sure the serial port or IP is defined
     if (serialPort == null || serialPort.isEmpty()) {
@@ -215,6 +221,31 @@ public class ESP8266FS implements Tool {
       editor.statusError("SPIFFS Error: serial port not defined!");
       return;
     }
+
+    // Find upload.py, don't fail if not present for backwards compat
+    File uploadPyFile = new File(platform.getFolder()+"/tools", "upload.py");
+    if (uploadPyFile.exists() && uploadPyFile.isFile()) {
+      uploadCmd = uploadPyFile.getAbsolutePath();
+    }
+    // Find python.exe if present, don't fail if not found for backwards compat
+    String toolPyCmd = pythonCmd;
+    if ((toolPyCmd != null ) && !toolPyCmd.isEmpty()) {
+      File toolPyFile = new File(platform.getFolder()+"/tools", toolPyCmd);
+      if (toolPyFile.exists() && toolPyFile.isFile() && toolPyFile.canExecute()) {
+        pythonCmd = toolPyFile.getAbsolutePath();
+      } else {
+        toolPyFile = new File(platform.getFolder()+"/tools/python", toolPyCmd);
+        if (toolPyFile.exists() && toolPyFile.isFile() && toolPyFile.canExecute()) {
+          pythonCmd = toolPyFile.getAbsolutePath();
+        } else {
+          toolPyFile = new File(PreferencesData.get("runtime.tools.python.path"), toolPyCmd);
+          if (toolPyFile.exists() && toolPyFile.isFile() && toolPyFile.canExecute()) {
+            pythonCmd = toolPyFile.getAbsolutePath();
+          }
+        }
+      }
+    }
+    // pythonCmd now points to either an installed exe with full path or just plain "python(.exe)"
 
     //find espota if IP else find esptool
     if(serialPort.split("\\.").length == 4){
@@ -233,7 +264,7 @@ public class ESP8266FS implements Tool {
         esptool = new File(platform.getFolder()+"/tools/esptool", esptoolCmd);
         if(!esptool.exists()){
           esptool = new File(PreferencesData.get("runtime.tools.esptool.path"), esptoolCmd);
-          if (!esptool.exists()) {
+          if (!esptool.exists() && uploadCmd.isEmpty()) {
               System.err.println();
               editor.statusError("SPIFFS Error: esptool not found!");
               return;
@@ -278,10 +309,10 @@ public class ESP8266FS implements Tool {
     }
 
     editor.statusNotice("SPIFFS Creating Image...");
-    System.out.println("[SPIFFS] data   : "+dataPath);
-    System.out.println("[SPIFFS] size   : "+((spiEnd - spiStart)/1024));
-    System.out.println("[SPIFFS] page   : "+spiPage);
-    System.out.println("[SPIFFS] block  : "+spiBlock);
+    System.out.println("[SPIFFS] data    : "+dataPath);
+    System.out.println("[SPIFFS] size    : "+((spiEnd - spiStart)/1024));
+    System.out.println("[SPIFFS] page    : "+spiPage);
+    System.out.println("[SPIFFS] block   : "+spiBlock);
 
     try {
       if(listenOnProcess(new String[]{toolPath, "-c", dataPath, "-p", spiPage+"", "-b", spiBlock+"", "-s", (spiEnd - spiStart)+"", imagePath}) != 0){
@@ -296,25 +327,27 @@ public class ESP8266FS implements Tool {
     }
 
     editor.statusNotice("SPIFFS Uploading Image...");
-    System.out.println("[SPIFFS] upload : "+imagePath);
+    System.out.println("[SPIFFS] upload  : "+imagePath);
     
     if(isNetwork){
-      String pythonCmd;
-      if(PreferencesData.get("runtime.os").contentEquals("windows"))
-          pythonCmd = "python.exe";
-      else
-          pythonCmd = "python";
-      
-      System.out.println("[SPIFFS] IP     : "+serialPort);
+      System.out.println("[SPIFFS] IP       : "+serialPort);
       System.out.println();
       sysExec(new String[]{pythonCmd, espota.getAbsolutePath(), "-i", serialPort, "-s", "-f", imagePath});
     } else {
-      System.out.println("[SPIFFS] address: "+uploadAddress);
-      System.out.println("[SPIFFS] reset  : "+resetMethod);
-      System.out.println("[SPIFFS] port   : "+serialPort);
-      System.out.println("[SPIFFS] speed  : "+uploadSpeed);
+      System.out.println("[SPIFFS] address  : "+uploadAddress);
+      System.out.println("[SPIFFS] reset    : "+resetMethod);
+      System.out.println("[SPIFFS] port     : "+serialPort);
+      System.out.println("[SPIFFS] speed    : "+uploadSpeed);
+      if (uploadCmd != null && !uploadCmd.isEmpty()) {
+        System.out.println("[SPIFFS] python   : "+pythonCmd);
+        System.out.println("[SPIFFS] uploader : "+uploadCmd);
+      }
       System.out.println();
-      sysExec(new String[]{esptool.getAbsolutePath(), "-cd", resetMethod, "-cb", uploadSpeed, "-cp", serialPort, "-ca", uploadAddress, "-cf", imagePath});
+      if (uploadCmd != null && !uploadCmd.isEmpty()) {
+        sysExec(new String[]{pythonCmd, uploadCmd, "--chip", "esp8266", "--port", serialPort, "--baud", uploadSpeed, "write_flash", uploadAddress, imagePath, "--end"});
+      } else {
+        sysExec(new String[]{esptool.getAbsolutePath(), "-cd", resetMethod, "-cb", uploadSpeed, "-cp", serialPort, "-ca", uploadAddress, "-cf", imagePath});
+      }
     }
   }
 

--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -208,11 +208,7 @@ public class ESP8266FS implements Tool {
     File espota = new File(platform.getFolder()+"/tools");
     File esptool = new File(platform.getFolder()+"/tools");
     String serialPort = PreferencesData.get("serial.port");
-    String pythonCmd;
-    if(PreferencesData.get("runtime.os").contentEquals("windows"))
-      pythonCmd = "python.exe";
-    else
-      pythonCmd = "python";
+    String pythonCmd = PreferencesData.get("runtime.os").contentEquals("windows") ? "python.exe" : "python";
     String uploadCmd = "";
     
     //make sure the serial port or IP is defined
@@ -228,21 +224,12 @@ public class ESP8266FS implements Tool {
       uploadCmd = uploadPyFile.getAbsolutePath();
     }
     // Find python.exe if present, don't fail if not found for backwards compat
-    String toolPyCmd = pythonCmd;
-    if ((toolPyCmd != null ) && !toolPyCmd.isEmpty()) {
-      File toolPyFile = new File(platform.getFolder()+"/tools", toolPyCmd);
+    String[] paths = { platform.getFolder()+"/tools", platform.getFolder()+"/tools/python", PreferencesData.get("runtime.tools.python.path") };
+    for (String s: paths) {
+      File toolPyFile = new File(s, pythonCmd);
       if (toolPyFile.exists() && toolPyFile.isFile() && toolPyFile.canExecute()) {
         pythonCmd = toolPyFile.getAbsolutePath();
-      } else {
-        toolPyFile = new File(platform.getFolder()+"/tools/python", toolPyCmd);
-        if (toolPyFile.exists() && toolPyFile.isFile() && toolPyFile.canExecute()) {
-          pythonCmd = toolPyFile.getAbsolutePath();
-        } else {
-          toolPyFile = new File(PreferencesData.get("runtime.tools.python.path"), toolPyCmd);
-          if (toolPyFile.exists() && toolPyFile.isFile() && toolPyFile.canExecute()) {
-            pythonCmd = toolPyFile.getAbsolutePath();
-          }
-        }
+        break;
       }
     }
     // pythonCmd now points to either an installed exe with full path or just plain "python(.exe)"
@@ -338,12 +325,12 @@ public class ESP8266FS implements Tool {
       System.out.println("[SPIFFS] reset    : "+resetMethod);
       System.out.println("[SPIFFS] port     : "+serialPort);
       System.out.println("[SPIFFS] speed    : "+uploadSpeed);
-      if (uploadCmd != null && !uploadCmd.isEmpty()) {
+      if (!uploadCmd.isEmpty()) {
         System.out.println("[SPIFFS] python   : "+pythonCmd);
         System.out.println("[SPIFFS] uploader : "+uploadCmd);
       }
       System.out.println();
-      if (uploadCmd != null && !uploadCmd.isEmpty()) {
+      if (!uploadCmd.isEmpty()) {
         sysExec(new String[]{pythonCmd, uploadCmd, "--chip", "esp8266", "--port", serialPort, "--baud", uploadSpeed, "write_flash", uploadAddress, imagePath, "--end"});
       } else {
         sysExec(new String[]{esptool.getAbsolutePath(), "-cd", resetMethod, "-cb", uploadSpeed, "-cp", serialPort, "-ca", uploadAddress, "-cf", imagePath});


### PR DESCRIPTION
When present, use a tools-installed python executable for any python
calls.

When tools/upload.py is present, use it in place of esptool-ck.exe.

When neither of these are present, as in releases 2.5.0 and prior, use
the prior behavior, unchanged.