### PR TITLE
Fix uploader for python3 compat and core 2.6.x

### DIFF
--- a/src/ESP8266FS.java
+++ b/src/ESP8266FS.java
@@ -208,7 +208,7 @@ public class ESP8266FS implements Tool {
     File espota = new File(platform.getFolder()+"/tools");
     File esptool = new File(platform.getFolder()+"/tools");
     String serialPort = PreferencesData.get("serial.port");
-    String pythonCmd = PreferencesData.get("runtime.os").contentEquals("windows") ? "python.exe" : "python";
+    String pythonCmd = PreferencesData.get("runtime.os").contentEquals("windows") ? "python3.exe" : "python3";
     String uploadCmd = "";
     
     //make sure the serial port or IP is defined
@@ -224,7 +224,7 @@ public class ESP8266FS implements Tool {
       uploadCmd = uploadPyFile.getAbsolutePath();
     }
     // Find python.exe if present, don't fail if not found for backwards compat
-    String[] paths = { platform.getFolder()+"/tools", platform.getFolder()+"/tools/python", PreferencesData.get("runtime.tools.python.path") };
+    String[] paths = { platform.getFolder()+"/tools", platform.getFolder()+"/tools/python3", PreferencesData.get("runtime.tools.python3.path") };
     for (String s: paths) {
       File toolPyFile = new File(s, pythonCmd);
       if (toolPyFile.exists() && toolPyFile.isFile() && toolPyFile.canExecute()) {
@@ -232,7 +232,7 @@ public class ESP8266FS implements Tool {
         break;
       }
     }
-    // pythonCmd now points to either an installed exe with full path or just plain "python(.exe)"
+    // pythonCmd now points to either an installed exe with full path or just plain "python3(.exe)"
 
     //find espota if IP else find esptool
     if(serialPort.split("\\.").length == 4){
@@ -331,7 +331,7 @@ public class ESP8266FS implements Tool {
       }
       System.out.println();
       if (!uploadCmd.isEmpty()) {
-        sysExec(new String[]{pythonCmd, uploadCmd, "--chip", "esp8266", "--port", serialPort, "--baud", uploadSpeed, "write_flash", uploadAddress, imagePath, "--end"});
+        sysExec(new String[]{pythonCmd, uploadCmd, "--chip", "esp8266", "--port", serialPort, "--baud", uploadSpeed, "write_flash", uploadAddress, imagePath});
       } else {
         sysExec(new String[]{esptool.getAbsolutePath(), "-cd", resetMethod, "-cb", uploadSpeed, "-cp", serialPort, "-ca", uploadAddress, "-cf", imagePath});
       }


### PR DESCRIPTION
The core moved to python3 because python (2) is EOL on January 1, 2020.
Move the search paths and platform variables to use python3 instead.

Remove the no longer needed --end parameter to upload.py